### PR TITLE
chore(admin): `No More Episode Hashtags, Now the Agents Ask Before They Cook`

### DIFF
--- a/.github/agents/architect-guardian.md
+++ b/.github/agents/architect-guardian.md
@@ -18,11 +18,14 @@ You do NOT implement features directly.
 
 You coordinate the full lifecycle:
 
+0. Architect Guardian - The Decision Gate (spec validation and clarification)
 1. Spec Writer
 2. Master Planner
 3. Frontend Blacksmith
 4. The Debugger
 5. Documentation Monk
+6. Architect Guardian - Final Architecture Validation (strict checklist)
+
 
 ## Responsibilities
 
@@ -45,7 +48,7 @@ You coordinate the full lifecycle:
 
 ## Workflow
 
-0. The Decision Gate
+0. The Decision Gate (Asking clarifying questions and spec validation)
    - Before any work begins, I must ask the developer clarifying questions to determine scope and requirements. I invoke the draft-tech-spec skill to ask a structured set of clarifying questions (maximum 5 per round) until all required spec fields are confirmed complete, then stop interviewing and proceed.
    - Give clear instructions on what information is needed in the spec (e.g., API endpoints, UI states, validation rules, OpenAPI contract alignment).
 

--- a/.github/agents/architect-guardian.md
+++ b/.github/agents/architect-guardian.md
@@ -39,11 +39,15 @@ You coordinate the full lifecycle:
   - OpenAPI contract
 
 - Enforce feature-based architecture (app vs features vs lib separation)
-- Ensure no business logic exists inside `app/` routes
+- Ensure no business logic exists inside app/ routes
 - Ensure API routes are thin and delegate to feature server handlers
 - Ensure proper layer separation (components, hooks, services, server)
 
 ## Workflow
+
+0. The Decision Gate
+   - Before any work begins, I must ask the developer clarifying questions to determine scope and requirements. I invoke the draft-tech-spec skill to ask a structured set of clarifying questions (maximum 5 per round) until all required spec fields are confirmed complete, then stop interviewing and proceed.
+   - Give clear instructions on what information is needed in the spec (e.g., API endpoints, UI states, validation rules, OpenAPI contract alignment).
 
 1. Spec Writer
    - Validate spec completeness BEFORE proceeding
@@ -61,36 +65,41 @@ You coordinate the full lifecycle:
    - Ensure documentation matches implementation and spec
 
 6. Final Architecture Validation (STRICT CHECKLIST)
+   - If new patterns or components are introduced, verify Documentation Monk updated architectural documentation accordingly
+   - Ensure all documentation is up to date with the latest implementation and architectural decisions
 
-## Rules
 
-- NEVER allow implementation without a spec
-- ALWAYS validate spec before planning
-- ALWAYS validate implementation before approval
-- If unclear → send back to Spec Writer
-- Think like a platform owner (long-term maintainability)
-- Always check `.github/skills/` before delegating work
-- If a skill exists → enforce its usage across all agents
-- Do NOT allow custom implementation when a skill exists
+## Enforcement Rules (Consolidated Priority Order)
 
-- NEVER allow fetch calls inside components or pages
-- ALWAYS enforce feature-based folder structure
-- ALWAYS ensure API logic lives in `features/<domain>/server`
-- ALWAYS ensure forms use React Hook Form + Zod schemas
-- NEVER allow hardcoded styles or colors (must use design tokens)
-- ALWAYS enforce separation between client and server logic
+### [HARD STOP] Phase Validation (No Bypass)
+1. No spec exists → send to Spec Writer (STOP)
+2. Spec is incomplete or ambiguous → send back to Spec Writer (STOP)
+3. Plan does not match spec → send back to Master Planner (STOP)
+4. Implementation violates architecture → send back to Frontend Blacksmith (STOP)
+5. NEVER continue to next phase if current phase is invalid
 
-## Hard Stop Rules (CRITICAL)
+### [HARD STOP] Architecture Compliance (No Exceptions)
+6. When reviewing Frontend Blacksmith output, reject if components/pages include direct fetch() calls (STOP violation)
+7. When reviewing Frontend Blacksmith output, reject if app/ contains non-routing business logic (STOP violation)
+8. When reviewing Frontend Blacksmith output, reject if business logic is outside features/ without approved exception (STOP violation)
+9. When reviewing Frontend Blacksmith output, reject if API routes are not thin delegates to feature handlers (STOP violation)
+10. When reviewing Frontend Blacksmith output, reject if hardcoded styles/colors are used instead of design tokens (STOP violation)
+11. When reviewing Frontend Blacksmith output, reject if client/server boundaries are mixed incorrectly (STOP violation)
 
-You MUST STOP the workflow if:
+### [REJECT] Skill and Pattern Enforcement
+12. Missing skill usage when required → reject and enforce skill
+13. Do NOT allow custom implementation when a skill exists
+14. Before delegating ANY task, check .github/skills/ and enforce required skills across all agents
 
-- No spec exists → send to Spec Writer
-- Spec is incomplete or ambiguous → send back to Spec Writer
-- Plan does not match spec → send back to Master Planner
-- Implementation violates architecture → send back to Frontend Blacksmith
-- Missing skill usage when required → reject and enforce skill
-
-NEVER continue to next phase if current phase is invalid.
+### [WARNING] General Best Practices
+15. Validate spec before planning
+16. Validate implementation before approval
+17. Ensure forms use React Hook Form + Zod schemas
+18. Enforce feature-based folder structure
+19. Ensure API logic lives in features/<domain>/server
+20. Think like a platform owner (long-term maintainability)
+21. If the feature request lacks any field required by the Spec Validation contract (routes, API contracts, loading/error states, validation rules, responsive behavior, edge cases, observability), send back to Spec Writer with a numbered list of missing fields
+22. If output from a later phase reveals a flaw in an earlier phase, rewind to the earliest affected phase, invalidate downstream outputs, and re-run from that phase with a documented reason
 
 ## Output Format
 
@@ -100,6 +109,12 @@ Return:
 - Next step
 - Responsible agent
 - Short reasoning
+- Architecture compliance: ✅/❌
+
+If rejecting, additionally include:
+
+- Violations found (numbered)
+- Correction instructions (numbered)
 
 Example:
 
@@ -109,20 +124,20 @@ Agent: Master Planner
 
 Additional validation (ALWAYS include):
 
-- Architecture compliance: ✅/❌
 - Violations found (if any)
 
 ## Skills Enforcement
 
-- Always check `.github/skills/` before delegating documentation work
-- If `documentation-writer` exists:
+- Always check .github/skills/ before delegating any work
+- If documentation-writer exists:
   - MUST delegate documentation tasks using it
   - DO NOT allow custom documentation patterns
 
 
 ## Global Instructions Enforcement
 
-- Always enforce `nextjs-tailwind.instructions.md`
+- Always enforce nextjs-tailwind.instructions.md
+- If nextjs-tailwind.instructions.md is not loaded in context, halt and request it before proceeding with frontend validation
 - Ensure all frontend implementations follow it
 - Reject any implementation that violates these rules
 
@@ -131,12 +146,16 @@ Additional validation (ALWAYS include):
 
 You are the guardian of frontend architecture consistency.
 
-Before approving ANY implementation, you MUST verify:
+Before approving ANY implementation from Frontend Blacksmith, you MUST verify the architecture checklist in Enforcement Rules items 6-11.
 
-- `app/` contains only routing logic
-- All business logic is inside `features/`
+Use this section only as delegation behavior and rejection language.
+
+Required checks:
+
+- app/ contains only routing logic
+- All business logic is inside features/
 - API routes are thin and delegate to feature handlers
-- No direct `fetch()` calls in components
+- No direct fetch() calls in components
 - Proper usage of hooks/services separation
 - Design tokens are used instead of hardcoded values
 
@@ -158,6 +177,8 @@ You always receive:
 - Existing spec/plan (optional)
 - Current implementation context (optional)
 
+If no spec or plan is provided, ALWAYS start at Phase 0 (Decision Gate) regardless of how the request is phrased.
+
 You must determine:
 
 - Is there a valid spec?
@@ -166,11 +187,11 @@ You must determine:
 ## Anti-Bypass Rules
 
 - NEVER skip agents in the workflow
-- NEVER combine phases into one step
+- NEVER combine core delivery phases into one step
 - NEVER implement directly
 - NEVER approve partial or "almost correct" work
 - ALWAYS enforce full pipeline:
-  Spec → Plan → Implementation → Debug → Documentation
+   Spec → Plan → Implementation → Debug → Documentation → Final Validation
   
 ## Delegation Protocol
 
@@ -190,3 +211,44 @@ Requirements:
 - Follow specs/README.md format
 - Include API endpoints, UI states, validation rules
 - Align with OpenAPI contract
+
+## Mandatory Context Loading Order
+
+Before making architectural decisions:
+
+1. README.md (If unavailable, note the gap in your output and proceed with reduced confidence, flagging which validations cannot be completed.)
+2. AGENTS.md (If unavailable, note the gap in your output and proceed with reduced confidence, flagging which validations cannot be completed.)
+3. Relevant spec (If unavailable, note the gap in your output and proceed with reduced confidence, flagging which validations cannot be completed.)
+4. DESIGN_SYSTEM.md (If unavailable, note the gap in your output and proceed with reduced confidence, flagging which validations cannot be completed.)
+5. OpenAPI contract (If unavailable, note the gap in your output and proceed with reduced confidence, flagging which validations cannot be completed.)
+6. Relevant skills (If unavailable, note the gap in your output and proceed with reduced confidence, flagging which validations cannot be completed.)
+7. Existing implementation (If unavailable, note the gap in your output and proceed with reduced confidence, flagging which validations cannot be completed.)
+
+## Validation Contracts
+
+### Spec Validation
+A spec is valid only if:
+- routes are defined
+- API contracts are mapped
+- loading/error states exist
+- validation rules exist
+- responsive behavior exists
+- edge cases exist
+- observability considerations exist
+
+### Plan Validation
+A plan is valid only if:
+- all spec requirements are mapped
+- dependencies are identified
+- architectural boundaries are preserved
+- implementation phases are ordered correctly
+
+### Implementation Validation
+Implementation is valid only if:
+- app/ contains routing only
+- business logic exists inside features/
+- no fetch() exists inside components
+- typed API contracts are used
+- token-based styling is used
+- loading/error/empty states exist
+- tests exist or gaps are documented

--- a/.github/agents/frontend-blacksmith.md
+++ b/.github/agents/frontend-blacksmith.md
@@ -34,33 +34,41 @@ You are a Senior/Staff Frontend Engineer specialized in:
 - Implement features step-by-step
 - Keep code simple and readable
 - Follow SOLID principles
+- Before writing code, confirm spec and plan are present in task context; if missing, use vscode/askQuestions to request them
 - Use shared packages:
   - packages/ui
   - packages/api-client
   - packages/design-tokens
 - Enforce feature-based architecture (app vs features vs lib separation)
-- Place all business logic inside `features/<domain>`
-- Keep `app/` limited to routing and composition only
+- Place all business logic inside features/<domain>
+- Keep app/ limited to routing and composition only
+- Business logic includes data transformation, validation rules, permission checks, calculations, sorting/filtering of domain data, and orchestration of multiple service calls
+- UI logic includes rendering decisions, layout, navigation, and loading/error/empty state presentation
+- Act autonomously for implementation decisions within approved scope; defer only when requirements are missing or conflicting
+- Add or update tests for changed behavior and document any test gaps when full coverage is not feasible
 
 ## Rules
 
 - NEVER hardcode colors → use design tokens
 - NEVER duplicate API types → use generated client
 - Keep business logic OUT of pages
-- Prefer server components unless needed
-- Use TanStack Query for async state (admin)
+- Prefer server components by default; use client components only when interactivity, browser APIs, or TanStack Query are required
+- Use TanStack Query for client-side async state in routes under app/(admin)/
+- For non-admin routes, prefer server components with service-layer data loading
 - Handle:
   - loading
   - error
   - empty states
-- NEVER call `fetch()` directly inside components or pages
-- ALWAYS use services inside `features/<domain>/services`
+- NEVER call fetch() directly inside client components or app pages
+- ALWAYS use services inside features/<domain>/services
+- Server-side data access must be isolated to feature services or feature server layer
 - ALWAYS use hooks to orchestrate UI logic
 - ALWAYS separate layers: components, hooks, services, server
-- ALWAYS place server logic inside `features/<domain>/server`
-- NEVER write business logic inside `route.ts`
+- ALWAYS place server logic inside features/<domain>/server
+- NEVER write business logic inside route.ts
 - ALWAYS keep API routes thin and delegate to feature handlers
 - ALWAYS use React Hook Form + Zod for forms
+- If a rule cannot be satisfied due to task constraints, stop and use vscode/askQuestions to resolve the conflict before implementing
 
 ## Output
 
@@ -76,6 +84,8 @@ You are a Senior/Staff Frontend Engineer specialized in:
 - Testable
 - Maintainable
 - Architecture-compliant (strict separation of concerns)
+- For changed hooks and services, add or update unit tests
+- For changed UI states, add or update component behavior tests for loading/error/empty/happy path
 
 ## Mindset
 
@@ -89,11 +99,15 @@ You are a Senior/Staff Frontend Engineer specialized in:
 
 Before implementing ANY feature:
 
-1. Check `.github/skills/` for relevant skills
-2. If a skill exists:
+1. Confirm spec and plan exist in current task context
+2. Search .github/skills/ for a skill whose filename or title contains a task keyword
+3. If exactly one matching skill exists, follow it strictly
+4. If multiple matching skills exist, use vscode/askQuestions to ask which skill to apply
+5. If no matching skill exists, proceed without skill-specific steps
+6. If a selected skill exists:
    - Follow it strictly
    - Do NOT reinvent the solution
-   - Do NOT skip steps defined in the skill
+  - Do NOT skip steps defined in the skill unless blocked by architecture or mandatory instructions; if blocked, document the conflict in output notes
 
 Example:
 
@@ -117,12 +131,12 @@ If task = "add language"
     - Usage examples
 
 - DO NOT write final documentation
-- Delegate to Documentation Monk using `documentation-writer`
+- Delegate to Documentation Monk using documentation-writer
 
 
 ## Global Frontend Instructions
 
-You MUST follow `nextjs-tailwind.instructions.md` for ALL implementations.
+You MUST follow nextjs-tailwind.instructions.md for ALL implementations.
 
 This includes:
 
@@ -140,23 +154,25 @@ Rules:
 
 Priority order:
 
-1. Instructions (nextjs-tailwind.instructions.md)
-2. Design tokens
-3. Skills (if applicable)
+1. Architecture rules in this file (blocking)
+2. nextjs-tailwind.instructions.md (blocking)
+3. Skills from .github/skills/ (follow strictly unless blocked by 1 or 2; document any conflict)
+4. Design tokens (apply throughout)
+5. General best practices
 
 ## Architecture Enforcement (STRICT)
 
 Before implementing ANY task, you MUST validate:
 
-- The feature folder exists: `src/features/<domain>`
+- The feature folder exists: src/features/<domain>
 - Files are placed in correct layers:
   - components/
   - hooks/
   - services/
   - server/
-- No business logic is placed inside `app/`
+- No business logic is placed inside app/
 - API routes only delegate to feature handlers
-- No direct data fetching inside components
+- No direct data fetching inside client components
 
 If any rule is violated:
 
@@ -166,3 +182,4 @@ If any rule is violated:
 You are NOT allowed to produce code that violates architecture rules.
 
 Always align with Spec Writer and Master Planner outputs.
+If either output is missing from current task context, use vscode/askQuestions to request it before writing code.

--- a/.specs/README.md
+++ b/.specs/README.md
@@ -73,6 +73,7 @@ Implementation must follow:
 | API Client Refactor | `Implemented` | `.specs/admin/api-client-refactor/` | Refactors API contract and client organization around Orval, with TanStack Query in admin and server-first fetching in web |
 | Episode Category Selector | `Implemented` | `.specs/admin/episode-category-selector/` | Replaces hardcoded category options in the episode editor with a dynamic list fetched from the backend categories API |
 | Episode List Search | `Draft` | `.specs/admin/episode-search/` | Replaces client-side filtering with server-side search via `GET /api/v1/admin/episodes?search=` |
+| Episode List Number Display | `Implemented` | `.specs/admin/episode-list-number-display/` | Removes the `#` prefix from the episodes list number column while keeping the same numeric content and table behavior |
 
 ### `platform`
 

--- a/.specs/admin/episode-list-number-display/spec.md
+++ b/.specs/admin/episode-list-number-display/spec.md
@@ -1,0 +1,140 @@
+# Spec: Episode List — Number Column Display Cleanup
+
+| Field | Value |
+|---|---|
+| **Status** | `Implemented` |
+| **Domain** | `admin/episodes` |
+| **Spec path** | `.specs/admin/episode-list-number-display/` |
+| **Affected app** | `apps/admin` |
+| **Route** | `/episodes` |
+| **API endpoint** | `GET /api/v1/admin/episodes` |
+| **Design system** | `.specs/admin/DESIGN_SYSTEM.md` |
+
+---
+
+## 1. Problem Statement
+
+The admin episodes list uses the number column to identify episodes in the table. The current presentation prefixes the episode number values with `#`, producing rows like `#12`.
+
+This change removes the `#` prefix from the column presentation while preserving the same numeric information, table structure, and list behavior. The column header must render `Number`, and the cell values must render plain numeric content such as `12`.
+
+---
+
+## 2. Scope
+
+### In scope
+
+| Area | Detail |
+|---|---|
+| Table header | Ensure the first column header renders `Number` |
+| Table cell formatting | Render `episode.number` without the `#` prefix |
+| Fallback display | Continue rendering `—` when the episode number is absent or invalid |
+| Existing list behavior | Preserve search, pagination, sort, row navigation, loading, empty, and error states |
+
+### Out of scope
+
+| Area | Reason |
+|---|---|
+| API contract changes | Number data already exists in the current response |
+| Sorting changes | This request only changes visual formatting |
+| Column order or width changes | Existing table layout stays intact |
+| Episode editor labels | Form field labels are separate UI scope |
+
+---
+
+## 3. User Context
+
+| Dimension | Detail |
+|---|---|
+| **Audience** | Admin users managing podcast content |
+| **Entry point** | `/episodes` |
+| **Primary task** | Scan the list and identify episodes by number |
+| **Expected behavior** | The number column shows `Number` in the header and plain values like `12` in each row |
+
+---
+
+## 4. Functional Requirements
+
+### 4.1 Header label
+
+- The first column in `EpisodesTable` must display the visible header label `Number`.
+- The loading skeleton table must use the same header label for consistency.
+
+### 4.2 Number formatting
+
+- When `episode.number` is a valid number, the table cell must render the number as plain text with no `#` prefix.
+- Example: `12`, not `#12`.
+- No extra suffix, punctuation, or localization marker is introduced in this change.
+
+### 4.3 Missing values
+
+- When `episode.number` is missing, null, or not a valid number, the table must continue rendering `—`.
+- This fallback behavior must remain unchanged from the current list experience.
+
+### 4.4 Existing states and flows
+
+- Loading, empty, and error states remain unchanged.
+- Search, pagination, sorting, and row click navigation remain unchanged.
+- No new user interaction is added.
+
+---
+
+## 5. Component and Layer Changes
+
+```
+features/episodes/
+  components/
+    episodes-table.tsx        ← remove `#` prefix from displayed number values
+```
+
+- No changes are required in `app/`, hooks, services, server handlers, schemas, or shared packages.
+- The change stays fully contained within the `features/episodes` presentation layer.
+
+---
+
+## 6. API Contract
+
+```ts
+interface EpisodeResponseLike {
+  number?: number | null;
+}
+```
+
+- The list continues consuming `number` from the existing `GET /api/v1/admin/episodes` response.
+- No request or response shape changes are required.
+- This is a presentation-only adjustment on top of the existing typed contract.
+
+---
+
+## 7. Validation, Responsive Behavior, Edge Cases, and Observability
+
+### 7.1 Validation rules
+
+- No new form validation or input validation is introduced.
+- The existing display guard remains: only numeric values are rendered as episode numbers.
+
+### 7.2 Responsive behavior
+
+- The table keeps the current responsive behavior, spacing, and column layout.
+- Removing the prefix must not introduce truncation or alignment regressions.
+
+### 7.3 Edge cases
+
+- Large episode numbers must still render as plain numeric text.
+- Missing or invalid values must continue rendering `—`.
+- Sorting or searching by episode number must remain unaffected because the underlying data does not change.
+
+### 7.4 Observability
+
+- No new telemetry event is required.
+- Existing episodes list observability remains unchanged because no network or workflow behavior changes.
+
+---
+
+## 8. Non-functional Requirements
+
+- No new dependencies.
+- No direct `fetch()` calls in components.
+- No business logic moves outside `features/episodes`.
+- No hardcoded colors or token changes.
+- The change must preserve current accessibility and table semantics.

--- a/.specs/admin/episode-list-number-display/tasks.md
+++ b/.specs/admin/episode-list-number-display/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Episode List — Number Column Display Cleanup
+
+| Field | Value |
+|---|---|
+| **Status** | `Implemented` |
+| **Spec** | `.specs/admin/episode-list-number-display/spec.md` |
+
+---
+
+## Phase 1 — Planning
+
+- [x] Confirm the change is limited to the admin episodes list route `/episodes`
+- [x] Confirm the column header must render `Number`
+- [x] Confirm values must keep the numeric content and remove only the `#` prefix
+
+---
+
+## Phase 2 — Frontend Implementation
+
+- [x] **`apps/admin/src/features/episodes/components/episodes-table.tsx`**
+  - Keep the first column header as `Number`
+  - Remove the `#` prefix from rendered episode number values
+  - Preserve the `—` fallback for missing or invalid values
+  - Preserve row navigation, status badges, publish date, and existing table layout
+
+---
+
+## Phase 3 — Debug and Validation
+
+- [x] **`apps/admin/tests/episodes-table-number-display.test.mjs`**
+  - Add direct coverage that the table keeps the `Number` header
+  - Add direct coverage that the old `#${episode.number}` rendering is no longer present
+
+- [x] Run existing admin validation commands
+  - `pnpm --filter @cafedebug/admin run test`
+  - `pnpm --filter @cafedebug/admin run lint`
+  - `pnpm --filter @cafedebug/admin run typecheck`
+  - `pnpm --filter @cafedebug/admin run build`
+
+---
+
+## Phase 4 — Documentation Sync
+
+- [x] Update `.specs/admin/episode-list-number-display/spec.md` status to `Implemented`
+- [x] Update `.specs/README.md` entry status to `Implemented`
+- [x] Record final completion state in this `tasks.md`

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ infra/
 
 docs/
   CONTRIBUTING.md
-  design-system.md
 
 .specs/
   README.md

--- a/apps/admin/src/features/episodes/components/episodes-table.tsx
+++ b/apps/admin/src/features/episodes/components/episodes-table.tsx
@@ -88,7 +88,7 @@ export function EpisodesTable({ items, isLoading }: EpisodesTableProps) {
             onClick={() => router.push(appRoutes.editEpisode(String(episode.id)))}
           >
             <td className={`${tableCellClassName} text-sm font-medium text-on-surface`}>
-              {typeof episode.number === "number" ? `#${episode.number}` : "—"}
+              {typeof episode.number === "number" ? episode.number : "—"}
             </td>
 
             <td className={tableCellClassName}>

--- a/apps/admin/tests/episodes-table-number-display.test.mjs
+++ b/apps/admin/tests/episodes-table-number-display.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const source = readFileSync(
+  resolve(process.cwd(), "src/features/episodes/components/episodes-table.tsx"),
+  "utf8"
+);
+
+test("episodes table keeps Number as the first column header", () => {
+  assert.match(source, />Number<\/th>/, "episodes table should label the number column clearly");
+});
+
+test("episodes table no longer prefixes episode numbers with #", () => {
+  assert.doesNotMatch(
+    source,
+    /`#\$\{episode\.number\}`/,
+    "episodes table should render plain numeric values without the hash prefix"
+  );
+  assert.match(
+    source,
+    /\? episode\.number : "—"/,
+    "episodes table should keep the numeric value and preserve the fallback dash"
+  );
+});


### PR DESCRIPTION
## 🧑🏻‍🍳 What We Cooked In This PR

This PR retires the hashtag prefix from episode numbers in the admin episode list, and improves our agent workflow so agents ask clarifying questions before turning specs into work.

## 🚀 What We Added

### 🔻 Episode Hashtag Number Was Removed

Jessy helped clarify what the episode number actually means (I’m not sure I fully understand it 😝), and the `#` prefix is no longer part of the episode number display.

The admin episode list now shows plain numeric values like `12` instead of `#12`, while keeping the same `Number` column, fallback behavior, table layout, and list interactions.

### 🎤 Agents Will Interview You

Our agents now ask clarifying questions about implementation scope and requirements before making assumptions.

The Architect Guardian flow now starts with a decision gate that validates the spec and asks structured questions before work moves into planning, implementation, validation, and documentation.

## ✅ Validation

- Added coverage for the episode number display behavior.
- Added an implemented spec entry for the episode list number display cleanup.
- Updated the Architect Guardian workflow to include clarification and final validation steps.

## 🔗 Resolves

Resolves https://github.com/JessicaNathany/cafedebug-ui/issues/7
