### PR TITLE
chore(admin): improve local dev setup for Windows and document API workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 ###
 # CafeDebug monorepo local environment contract
 # Copy this file to `.env` and adjust values for your machine.
+# Host-run admin: also copy to apps/admin/.env.local (see README).
 ###
 
 ########################################
@@ -14,17 +15,20 @@ ADMIN_PORT=3010
 ADMIN_CONTAINER_PORT=3000
 
 # URL used by browsers when accessing the admin app.
-# Keep this aligned with ADMIN_PORT.
+# Docker Compose: align with ADMIN_PORT (3010). Host dev: use http://localhost:3001
 ADMIN_PUBLIC_URL=http://localhost:3010
 
 # Backend API base URL used by the admin app to call authenticated endpoints.
-# In local host-run workflows this can stay on localhost.
-# In Docker workflows, prefer ADMIN_API_BASE_URL_DOCKER where available.
+# Docker devstack (default): http://localhost:8080
+# Visual Studio on host (HTTPS): use your launch URL; see NODE_TLS below
 ADMIN_API_BASE_URL=http://localhost:8080
 
 # Backend API base URL used inside Docker containers.
 # This avoids localhost loopback confusion from inside containers.
 ADMIN_API_BASE_URL_DOCKER=http://host.docker.internal:8080
+
+# HTTPS dev cert only (apps/admin/.env.local). Not needed for http://localhost:8080
+# NODE_TLS_REJECT_UNAUTHORIZED=0
 
 # Environment mode for runtime behavior.
 # Use "development" for local compose hot reload and "production" for image/runtime checks.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,25 @@ Use this section when you want to run the admin app locally as a contributor.
 - pnpm `>= 10`
 - a running backend API reachable by `ADMIN_API_BASE_URL` (default `http://localhost:8080`)
 
+#### Backend API source (pick one)
+
+Host-run admin reads `ADMIN_API_BASE_URL` from `apps/admin/.env.local`. You can switch anytime — only change that URL (and TLS setting if needed).
+
+**A — Docker devstack (default, seeded test data)**
+
+Use when developing the frontend against a ready local API (MySQL/MinIO/API via Docker Compose from the backend devstack repo).
+
+1. Start the devstack (API healthy at `http://localhost:8080`).
+2. In `apps/admin/.env.local`: `ADMIN_API_BASE_URL=http://localhost:8080`
+3. Do not set `NODE_TLS_REJECT_UNAUTHORIZED`.
+
+**B — Visual Studio / IDE (backend debugging on the host)**
+
+Use when debugging or changing the API in Visual Studio (or `dotnet run`) while developing the admin UI at the same time. The API runs on the host, not in Docker — port/URL comes from your IDE launch profile (check Swagger).
+
+1. In `apps/admin/.env.local`: set `ADMIN_API_BASE_URL` to that URL (e.g. `https://localhost:7211`).
+2. HTTPS with a dev certificate: uncomment `NODE_TLS_REJECT_UNAUTHORIZED=0` in `apps/admin/.env.local` (see `.env.example`). Do not put it in `package.json` scripts.
+
 #### 1. Install dependencies
 
 From repository root:
@@ -263,20 +282,25 @@ Why this is needed:
 - Docker Compose reads the root `.env`.
 - Next.js host-run reads `apps/admin/.env.local` (app directory).
 
-Then confirm these values in `.env` for local development:
+Then confirm these values for **host-run admin** (`pnpm --filter @cafedebug/admin dev`) in `apps/admin/.env.local`:
 
-- `ADMIN_PORT=3010`
-- `ADMIN_PUBLIC_URL=http://localhost:3010`
-- `ADMIN_API_BASE_URL=http://localhost:8080`
+- `ADMIN_PUBLIC_URL=http://localhost:3001` (admin dev server port)
+- `ADMIN_API_BASE_URL=http://localhost:8080` (Docker/local API on HTTP)
 - `ADMIN_COOKIE_DOMAIN=localhost`
 - `ADMIN_COOKIE_SAMESITE=Lax`
 - `ADMIN_COOKIE_SECURE=false`
 
+For **admin in Docker Compose**, confirm these in the root `.env`:
+
+- `ADMIN_PORT=3010` (host port mapped to the admin container)
+- `ADMIN_CONTAINER_PORT=3000` (port Next.js listens on inside the container)
+- `ADMIN_PUBLIC_URL=http://localhost:3010` (must align with `ADMIN_PORT`)
+- `ADMIN_API_BASE_URL_DOCKER=http://host.docker.internal:8080`
+
 Notes:
 
-- If your API runs on another port/host, change `ADMIN_API_BASE_URL`.
-- Example for local .NET HTTPS API: `ADMIN_API_BASE_URL=https://localhost:7211`
-- `ADMIN_API_BASE_URL_DOCKER` is only for Docker-based runs.
+- API source (Docker devstack vs Visual Studio) and TLS rules: see **Backend API source (pick one)** above. Details in `.env.example`.
+- `ADMIN_API_BASE_URL_DOCKER` is only for Docker-based admin runs.
 
 #### 3. Start admin directly on host (recommended for daily coding)
 

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -1,15 +1,10 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@cafedebug/design-tokens", "@cafedebug/api-client"],
-  outputFileTracingRoot: path.join(
-    path.dirname(fileURLToPath(import.meta.url)),
-    "../.."
-  )
+  outputFileTracingRoot: new URL("../../", import.meta.url).pathname
 };
 
 export default withSentryConfig(nextConfig, {

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -1,10 +1,15 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@cafedebug/design-tokens", "@cafedebug/api-client"],
-  outputFileTracingRoot: new URL("../../", import.meta.url).pathname
+  outputFileTracingRoot: path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../.."
+  )
 };
 
 export default withSentryConfig(nextConfig, {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 next dev --port 3001",
+    "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start --port 3001",
     "lint": "eslint .",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 next dev --port 3001",
+    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 next dev --port 3001",
     "build": "next build",
     "start": "next start --port 3001",
     "lint": "eslint .",
@@ -50,7 +50,6 @@
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
     "autoprefixer": "^10.4.21",
-    "cross-env": "^7.0.3",
     "eslint": "^9.39.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 next dev --port 3001",
+    "dev": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 next dev --port 3001",
     "build": "next build",
     "start": "next start --port 3001",
     "lint": "eslint .",
@@ -50,6 +50,7 @@
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
     "autoprefixer": "^10.4.21",
+    "cross-env": "^7.0.3",
     "eslint": "^9.39.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,9 +117,6 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
-      cross-env:
-        specifier: ^7.0.3
-        version: 7.0.3
       eslint:
         specifier: ^9.39.0
         version: 9.39.4(jiti@1.21.7)
@@ -1997,11 +1994,6 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
-
-  cross-env@7.0.3:
-    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
-    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
-    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -5102,10 +5094,6 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   crelt@1.0.6: {}
-
-  cross-env@7.0.3:
-    dependencies:
-      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       eslint:
         specifier: ^9.39.0
         version: 9.39.4(jiti@1.21.7)
@@ -1994,6 +1997,11 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -5094,6 +5102,10 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   crelt@1.0.6: {}
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
## Summary

Improves the admin app local developer experience on **Windows, macOS, and Linux**, and documents how to connect the frontend to the backend in the two workflows we use day to day.

## Problem

New contributors (especially on **Windows**) hit avoidable setup issues:

1. **`pnpm dev` failed on Windows** — the dev script used `NODE_TLS_REJECT_UNAUTHORIZED=0 next dev`, which is bash-only syntax. macOS/Linux worked; Windows (PowerShell/cmd/Git Bash via `pnpm.cmd`) did not.
2. **`next build` / Turbopack failed on Windows** — `outputFileTracingRoot` used `new URL(...).pathname`, which produces invalid paths on Windows (`/C:/...`).
3. **Unclear API setup** — it wasn’t obvious how to point the admin app at the **Docker devstack** (seeded API on `:8080`) vs **Visual Studio** (API on the host, often HTTPS), or when `NODE_TLS_REJECT_UNAUTHORIZED` is actually needed.

## What changed

### `apps/admin/next.config.ts`
- Use `fileURLToPath` + `path.join` for `outputFileTracingRoot` (Next.js monorepo best practice).
- Fixes Turbopack/dev on Windows; unchanged behavior on Mac/Linux.

### `apps/admin/package.json`
- Dev script is now plain `next dev --port 3001` (works on all platforms).
- TLS bypass removed from scripts — it belongs in env, not npm scripts.

### `.env.example`
- Notes for host-run vs Docker admin ports (`3001` vs `3010`).
- Documents Docker devstack vs Visual Studio API URLs.
- Adds optional `NODE_TLS_REJECT_UNAUTHORIZED=0` (commented) for HTTPS dev certs only.

### `README.md`
- New **Backend API source (pick one)** section:
  - **A — Docker devstack** (default): `http://localhost:8080`, no TLS flag.
  - **B — Visual Studio / IDE**: host API URL + optional TLS in `.env.local`.
- Separates checklists for **host-run admin** vs **admin in Docker Compose**.
- Removes duplicated TLS/API notes (points to the section above + `.env.example`).

## Why this helps new devs

| Before | After |
|--------|--------|
| Windows clone → `pnpm dev` fails | Same commands work on Windows, Mac, Linux |
| Trial-and-error for API URL / TLS | Clear path: devstack **or** Visual Studio |
| TLS in `package.json` (platform-specific) | TLS only in `apps/admin/.env.local` when using HTTPS API |

**Typical frontend workflow after this PR:**

```bash
cp .env.example .env
cp .env.example apps/admin/.env.local
# Start devstack → API at http://localhost:8080
pnpm install
pnpm --filter @cafedebug/admin dev
# → http://localhost:3001